### PR TITLE
 Adding support for .slackrc so that the tool can be used with a default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 slacker==0.3.0
+rcfile==0.1.4

--- a/slacker_cli/__init__.py
+++ b/slacker_cli/__init__.py
@@ -6,6 +6,7 @@
 
 from slacker import Slacker
 import argparse
+from rcfile import rcfile
 import sys
 
 
@@ -16,8 +17,11 @@ def main():
     parser.add_argument("-t", "--token", help="Slack token")
 
     args = parser.parse_args()
-    token = args.token
-    channel = args.channel
+    rcargs = rcfile( "slacker", args.__dict__ )
+
+    token = args.token or rcargs['token']
+    channel = args.channel or rcargs['channel']
+
 
     if not token or not channel:
         exit(1)


### PR DESCRIPTION
token or even channel.

This was the token can be in scoped to the system, or the the user, or to the session by creating a .slackerrc or exporting environment variables like SLACKER_TOKEN.

Fun!
