### PR TITLE
new: add a symbolic link to the executable

### DIFF
--- a/slacker
+++ b/slacker
@@ -1,0 +1,1 @@
+slacker_cli/__init__.py


### PR DESCRIPTION
This allows to have a nice executable even when not installing it.
This happens often for devs that want to rely on the actual code,
or for admin that want to maintain their version up to date thanks
to git alone.