### PR TITLE
Make --as-user as flag option

### DIFF
--- a/slacker_cli/__init__.py
+++ b/slacker_cli/__init__.py
@@ -58,11 +58,11 @@ def args_priority(args, environ):
         token = arg_token
 
     # slack as_user
-    slack_as_user_var_name = 'SLACK_USERNAME'
-    as_user = environ.get(slack_as_user_var_name)
+    slack_as_user_var_name = 'SLACK_AS_USER'
+    as_user = bool(environ.get(slack_as_user_var_name))
 
     if arg_as_user:
-        as_user = arg_as_user
+        as_user = True
 
     return token, as_user, args.channel
 
@@ -75,7 +75,7 @@ def main():
     parser.add_argument("-t", "--token", help="Slack token")
     parser.add_argument("-f", "--file", help="File to upload")
     parser.add_argument("-n", "--name", help="Sender name")
-    parser.add_argument("-a", "--as-user", help="As user")
+    parser.add_argument("-a", "--as-user", action="store_true", help="As user")
     parser.add_argument("-i", "--icon-emoji", help="Sender emoji icon")
 
     args = parser.parse_args()

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -13,50 +13,50 @@ class TestArgs(TestCase):
 
     def test_args_priority_first_token_as_argument(self):
         self.parser.token = 'arg_token'
-        self.parser.as_user = 'arg_as_user'
+        self.parser.as_user = True
         self.parser.channel = 'channel'
         args = self.parser
         environ = {'SLACK_TOKEN': 'env_token',
-                   'SLACK_USERNAME': 'env_username'}
+                   'SLACK_AS_USER': 1}
 
         self.assertEqual(
-            ('arg_token', 'arg_as_user', 'channel'),
+            ('arg_token', True, 'channel'),
             args_priority(args, environ)
         )
 
     def test_args_priority_only_env_token(self):
         self.parser.token = None
-        self.parser.as_user = None
+        self.parser.as_user = False
         self.parser.channel = 'channel'
         args = self.parser
         environ = {'SLACK_TOKEN': 'env_token',
-                   'SLACK_USERNAME': 'env_username'}
+                   'SLACK_AS_USER': 1}
 
         self.assertEqual(
-            ('env_token', 'env_username', 'channel'),
+            ('env_token', 1, 'channel'),
             args_priority(args, environ)
         )
 
     def test_args_priority_only_arg_token(self):
         self.parser.token = 'arg_token'
-        self.parser.as_user = 'arg_username'
+        self.parser.as_user = True
         self.parser.channel = 'channel'
         args = self.parser
         environ = {}
 
         self.assertEqual(
-            ('arg_token', 'arg_username', 'channel'),
+            ('arg_token', True, 'channel'),
             args_priority(args, environ)
         )
 
     def test_args_priority_empty_args(self):
         self.parser.token = None
-        self.parser.as_user = None
+        self.parser.as_user = False
         self.parser.channel = None
         args = self.parser
         environ = {}
 
         self.assertEqual(
-            (None, None, None),
+            (None, False, None),
             args_priority(args, environ)
         )

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -15,7 +15,7 @@ class TestMessage(unittest.TestCase):
         channel = 'channel_name'
         message = 'message string'
         sender_name = None
-        as_user = None
+        as_user = False
         sender_icon = None
 
         post_message(token, channel, message,
@@ -29,7 +29,7 @@ class TestMessage(unittest.TestCase):
         channel = '#channel_name'
         message = 'message string'
         sender_name = None
-        as_user = None
+        as_user = False
         sender_icon = None
 
         post_message(token, channel, message,
@@ -37,7 +37,7 @@ class TestMessage(unittest.TestCase):
 
         mock_slacker.return_value.chat.post_message\
             .assert_called_with('#channel_name', message,
-                                username=None, as_user=None,
+                                username=None, as_user=False,
                                 icon_emoji=None)
 
     @patch('slacker_cli.Slacker')
@@ -46,7 +46,7 @@ class TestMessage(unittest.TestCase):
         channel = '#channel_name'
         message = 'message string'
         sender_name = 'test bot'
-        as_user = 'real user'
+        as_user = True
         sender_icon = ':dancer:'
 
         post_message(token, channel, message,


### PR DESCRIPTION
Beforehand, I sent PR: https://github.com/juanpabloaj/slacker-cli/pull/14 .
In that implementation, the --as-user option assumed be passed username, but I found it can be flag.
So another PR, this makes the command more simple.

This causes some problems to previous version user.
Because 
```
SLACK_USERNAME='wkentaro'
```
is renamed to 
```
SLACK_AS_USER=1  # or 0
```
and 
```
data | slacker -a wkentaro
```
does not work
but 
```
data | slacker -a
```