### PR TITLE
Support arbitrary additional data to be passed to post_message

### DIFF
--- a/slacker_cli/__init__.py
+++ b/slacker_cli/__init__.py
@@ -71,13 +71,14 @@ def upload_file(token, channel_name, file_name):
 
     slack.files.upload(file_name, channels=channel_name)
 
+
 def args_to_dict(lst):
     ret = {}
     for item in lst:
         # skip args with bad syntax
         if item.count('=') < 1:
             continue
-        k,v = item.split('=', 1)
+        k, v = item.split('=', 1)
         ret[k] = v
     return ret
 


### PR DESCRIPTION
The underlying `slacker` Python library supports additional argument types, like attachments={...}.

This PR captures that data from command-line and passes them to slacker.

Ex:
    echo 'oh noes!' | slacker-cli -n failbot -c ops attachments='[{"color":"red", "fallback":"oh noes!"}]'