### PR TITLE
Update dev requirements to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-slacker==0.5.7
-flake8==2.2.2
-nose==1.3.4
+slacker==0.9.40
+flake8==3.3.0
+nose==1.3.7
 nose-cov==1.6
-coveralls==0.4.2
-mock==1.0.1
-tox==1.9.0
+coveralls==1.1
+mock==2.0.0
+tox==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,10 @@ setup(
     },
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
     ]
 )


### PR DESCRIPTION
Fixes #29.

Also remove Python 2.6, which has been [unsupported since 2013](https://en.wikipedia.org/wiki/CPython#Version_history) and more and more libraries are dropping support for it too, including some of the dev ones.

Coverage is [now 94%!](https://coveralls.io/builds/10051705)
