### PR TITLE
Add Python 3.7. remove EOL 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,26 @@
 language: python
+cache: pip
+
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
   - pypy
+
+# Python 3.7 requires Xenial and sudo
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 install:
   - pip install -r requirements-dev.txt
+
 script:
   - nosetests --with-coverage
   - flake8 slacker_cli tests
+
 after_script:
   - coveralls --verbose

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-slacker==0.9.40
-flake8==3.3.0
+slacker==0.9.65
+flake8==3.5.0
 nose==1.3.7
 nose-cov==1.6
-coveralls==1.1
+coveralls==1.5.0
 mock==2.0.0
-tox==2.6.0
+tox==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-slacker==0.9.40
+slacker==0.9.65
 requests

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,6 @@ def read(*paths):
 
 
 install_requires = read('requirements.txt').splitlines()
-try:
-    import argparse
-except ImportError:
-    install_requires.append('argparse')
 
 
 setup(
@@ -35,12 +31,15 @@ setup(
             'slacker=slacker_cli:main',
         ],
     },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py27, py34, pypy
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
https://en.wikipedia.org/wiki/CPython#Version_history

A small workaround is needed for 3.7 in .travis.yml, see https://github.com/travis-ci/travis-ci/issues/9815.

This also updates the pinned requirements.