### PR TITLE
Fix ImportError: Update Slacker and module import

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-slacker==0.9.65
+slacker==0.13.0
 flake8==3.5.0
 nose==1.3.7
 nose-cov==1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-slacker==0.9.65
+slacker==0.13.0
 requests

--- a/slacker_cli/__init__.py
+++ b/slacker_cli/__init__.py
@@ -5,7 +5,7 @@
 """
 
 from slacker import Slacker
-from slacker.utils import get_item_id_by_name
+from slacker.utilities import get_item_id_by_name
 import requests
 import argparse
 import sys


### PR DESCRIPTION
Fixes #33 and https://github.com/os/slacker/issues/153.

Fixes this on Python 3:

```console
$ slacker --help
Traceback (most recent call last):
  File "/usr/local/bin/slacker", line 11, in <module>
    load_entry_point('slacker-cli', 'console_scripts', 'slacker')()
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2843, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2434, in load
    return self.resolve()
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2440, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/hugo/github/slacker-cli/slacker_cli/__init__.py", line 8, in <module>
    from slacker.utils import get_item_id_by_name
ModuleNotFoundError: No module named 'slacker.utils'
```

Similarly on Python 2:
```console
$ echo hello | slacker
Traceback (most recent call last):
  File "/env/bin/slacker", line 6, in <module>
    from slacker_cli import main
  File "/env/local/lib/python2.7/site-packages/slacker_cli/__init__.py", line 8, in <module>
    from slacker.utils import get_item_id_by_name
ImportError: No module named utils
```

This is because:

* The most recent Slacker release (0.13.0) renamed its `utils` module to `utilities` https://github.com/os/slacker/releases/tag/v0.13.0

* The version (0.4.0) of slacker-cli on PyPI requires `slacker>=0.7.3` (in requirements.txt)

* The unreleased master of slacker-cli pins to `slacker==0.9.65` so the tests pass

Fix it by upgrading the pin and renaming the module.
