### PR TITLE
Update pins + format code + fix coverage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E203
+max-line-length = 88

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pip install -U black; fi
 
 script:
-  - nosetests --with-coverage
+  - nosetests --with-coverage --cover-package=slacker_cli
   - flake8 slacker_cli tests
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff .; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then black --check --diff .; fi
 
 after_script:
   - coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ matrix:
 
 install:
   - pip install -r requirements-dev.txt
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pip install -U black; fi
 
 script:
   - nosetests --with-coverage
   - flake8 slacker_cli tests
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff .; fi
 
 after_script:
   - coveralls --verbose

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 slacker==0.13.0
-flake8==3.5.0
+flake8==3.7.7
 nose==1.3.7
 nose-cov==1.6
-coveralls==1.5.0
-mock==2.0.0
-tox==3.4.0
+coveralls==1.7.0
+mock==3.0.5
+tox==3.11.1

--- a/setup.py
+++ b/setup.py
@@ -7,38 +7,34 @@ from setuptools import setup
 
 def read(*paths):
     """ read files """
-    with open(os.path.join(*paths), 'r') as filename:
+    with open(os.path.join(*paths), "r") as filename:
         return filename.read()
 
 
-install_requires = read('requirements.txt').splitlines()
+install_requires = read("requirements.txt").splitlines()
 
 
 setup(
     name="slacker-cli",
     version="0.4.1",
     description="Send messages to slack from command line",
-    long_description=(read('README.rst')),
+    long_description=(read("README.rst")),
     url="https://github.com/juanpabloaj/slacker-cli",
     install_requires=install_requires,
-    license='MIT',
+    license="MIT",
     author="JuanPablo AJ",
     author_email="jpabloaj@gmail.com",
-    packages=['slacker_cli'],
+    packages=["slacker_cli"],
     test_suite="tests",
-    entry_points={
-        'console_scripts': [
-            'slacker=slacker_cli:main',
-        ],
-    },
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    entry_points={"console_scripts": ["slacker=slacker_cli:main"]},
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-    ]
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
 )

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -7,47 +7,35 @@ from slacker_cli import args_priority
 
 
 class TestArgs(TestCase):
-
     def setUp(self):
         self.parser = argparse.ArgumentParser()
 
     def test_args_priority_first_token_as_argument(self):
-        self.parser.token = 'arg_token'
+        self.parser.token = "arg_token"
         self.parser.as_user = True
-        self.parser.channel = 'channel'
+        self.parser.channel = "channel"
         args = self.parser
-        environ = {'SLACK_TOKEN': 'env_token',
-                   'SLACK_AS_USER': 1}
+        environ = {"SLACK_TOKEN": "env_token", "SLACK_AS_USER": 1}
 
-        self.assertEqual(
-            ('arg_token', True, 'channel'),
-            args_priority(args, environ)
-        )
+        self.assertEqual(("arg_token", True, "channel"), args_priority(args, environ))
 
     def test_args_priority_only_env_token(self):
         self.parser.token = None
         self.parser.as_user = False
-        self.parser.channel = 'channel'
+        self.parser.channel = "channel"
         args = self.parser
-        environ = {'SLACK_TOKEN': 'env_token',
-                   'SLACK_AS_USER': 1}
+        environ = {"SLACK_TOKEN": "env_token", "SLACK_AS_USER": 1}
 
-        self.assertEqual(
-            ('env_token', 1, 'channel'),
-            args_priority(args, environ)
-        )
+        self.assertEqual(("env_token", 1, "channel"), args_priority(args, environ))
 
     def test_args_priority_only_arg_token(self):
-        self.parser.token = 'arg_token'
+        self.parser.token = "arg_token"
         self.parser.as_user = True
-        self.parser.channel = 'channel'
+        self.parser.channel = "channel"
         args = self.parser
         environ = {}
 
-        self.assertEqual(
-            ('arg_token', True, 'channel'),
-            args_priority(args, environ)
-        )
+        self.assertEqual(("arg_token", True, "channel"), args_priority(args, environ))
 
     def test_args_priority_empty_args(self):
         self.parser.token = None
@@ -56,7 +44,4 @@ class TestArgs(TestCase):
         args = self.parser
         environ = {}
 
-        self.assertEqual(
-            (None, False, None),
-            args_priority(args, environ)
-        )
+        self.assertEqual((None, False, None), args_priority(args, environ))

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -8,82 +8,111 @@ from slacker_cli import post_message, SlackerCliError
 
 
 class TestMessage(unittest.TestCase):
-
-    @patch('slacker_cli.Slacker')
+    @patch("slacker_cli.Slacker")
     def test_post_message_use_token(self, mock_slacker):
-        token = 'aaa'
-        channel = 'channel_name'
-        message = 'message string'
+        token = "aaa"
+        channel = "channel_name"
+        message = "message string"
         sender_name = None
         as_user = False
         sender_icon = None
         as_slackbot = False
         team = None
 
-        post_message(token, channel, message,
-                     sender_name, as_user, sender_icon,
-                     as_slackbot, team)
+        post_message(
+            token,
+            channel,
+            message,
+            sender_name,
+            as_user,
+            sender_icon,
+            as_slackbot,
+            team,
+        )
 
         mock_slacker.assert_called_with(token)
 
-    @patch('slacker_cli.Slacker')
+    @patch("slacker_cli.Slacker")
     def test_post_message_use_channel_name(self, mock_slacker):
-        token = 'aaa'
-        channel = '#channel_name'
-        message = 'message string'
+        token = "aaa"
+        channel = "#channel_name"
+        message = "message string"
         sender_name = None
         as_user = False
         sender_icon = None
         as_slackbot = False
         team = None
 
-        post_message(token, channel, message,
-                     sender_name, as_user, sender_icon,
-                     as_slackbot, team)
+        post_message(
+            token,
+            channel,
+            message,
+            sender_name,
+            as_user,
+            sender_icon,
+            as_slackbot,
+            team,
+        )
 
-        mock_slacker.return_value.chat.post_message\
-            .assert_called_with('#channel_name', message,
-                                username=None, as_user=False,
-                                icon_emoji=None)
+        mock_slacker.return_value.chat.post_message.assert_called_with(
+            "#channel_name", message, username=None, as_user=False, icon_emoji=None
+        )
 
-    @patch('slacker_cli.Slacker')
+    @patch("slacker_cli.Slacker")
     def test_post_message_use_sender_name(self, mock_slacker):
-        token = 'aaa'
-        channel = '#channel_name'
-        message = 'message string'
-        sender_name = 'test bot'
+        token = "aaa"
+        channel = "#channel_name"
+        message = "message string"
+        sender_name = "test bot"
         as_user = True
-        sender_icon = ':dancer:'
+        sender_icon = ":dancer:"
         as_slackbot = False
         team = None
 
-        post_message(token, channel, message,
-                     sender_name, as_user, sender_icon,
-                     as_slackbot, team)
+        post_message(
+            token,
+            channel,
+            message,
+            sender_name,
+            as_user,
+            sender_icon,
+            as_slackbot,
+            team,
+        )
 
-        mock_slacker.return_value.chat.post_message\
-            .assert_called_with('#channel_name', message,
-                                username=sender_name, as_user=as_user,
-                                icon_emoji=sender_icon)
+        mock_slacker.return_value.chat.post_message.assert_called_with(
+            "#channel_name",
+            message,
+            username=sender_name,
+            as_user=as_user,
+            icon_emoji=sender_icon,
+        )
 
-    @patch('slacker_cli.requests')
+    @patch("slacker_cli.requests")
     def test_post_message_as_slackbot(self, mock_requests):
-        token = 'aaa'
-        channel = '#channel_name'
-        message = 'message string'
+        token = "aaa"
+        channel = "#channel_name"
+        message = "message string"
         sender_name = None
         as_user = False
         sender_icon = None
         as_slackbot = True
-        team = 'team-name'
+        team = "team-name"
 
         try:
-            post_message(token, channel, message,
-                         sender_name, as_user, sender_icon,
-                         as_slackbot, team)
+            post_message(
+                token,
+                channel,
+                message,
+                sender_name,
+                as_user,
+                sender_icon,
+                as_slackbot,
+                team,
+            )
         except SlackerCliError:
             pass
 
-        url = 'https://team-name.slack.com/services/hooks/slackbot'
-        url += '?token=aaa&channel=%23channel_name'
+        url = "https://team-name.slack.com/services/hooks/slackbot"
+        url += "?token=aaa&channel=%23channel_name"
         mock_requests.post.assert_called_with(url, message)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,45 +8,33 @@ from slacker_cli import get_channel_id, get_im_id, get_item_by_key_value
 
 
 class TestChannels(unittest.TestCase):
-
-    @patch('slacker_cli.Slacker')
+    @patch("slacker_cli.Slacker")
     def test_get_channel_id(self, mock_slacker):
 
         mock_slacker.return_value.channels.list.return_value.body = {
-            'channels': [
-                {'name': 'general', 'id': 'C111'},
-                {'name': 'random', 'id': 'C222'}
+            "channels": [
+                {"name": "general", "id": "C111"},
+                {"name": "random", "id": "C222"},
             ]
         }
 
-        self.assertEqual(
-            'C111', get_channel_id('aaa', 'general')
-        )
+        self.assertEqual("C111", get_channel_id("aaa", "general"))
 
-    @patch('slacker_cli.Slacker')
+    @patch("slacker_cli.Slacker")
     def test_get_im_id(self, mock_slacker):
 
         mock_slacker.return_value.users.list.return_value.body = {
-            'members': [
-                {'name': 'bob', 'id': 'U111'},
-                {'name': 'john', 'id': 'U222'}
-            ]
+            "members": [{"name": "bob", "id": "U111"}, {"name": "john", "id": "U222"}]
         }
         mock_slacker.return_value.im.list.return_value.body = {
-            'ims': [
-                {'user': 'U111', 'id': 'IM111'},
-                {'user': 'U111', 'id': 'IM222'}
-            ]
+            "ims": [{"user": "U111", "id": "IM111"}, {"user": "U111", "id": "IM222"}]
         }
 
-        self.assertEqual(
-            'IM111', get_im_id('aaa', 'bob')
-        )
+        self.assertEqual("IM111", get_im_id("aaa", "bob"))
 
     def test_get_item_by_key_value(self):
-            list_dict = [{'user': 'user_id_1', 'id': '123'}, {}]
+        list_dict = [{"user": "user_id_1", "id": "123"}, {}]
 
-            self.assertEqual(
-                '123',
-                get_item_by_key_value(list_dict, 'user', 'user_id_1')['id'],
-            )
+        self.assertEqual(
+            "123", get_item_by_key_value(list_dict, "user", "user_id_1")["id"]
+        )


### PR DESCRIPTION
* Update pinned dev requirements to latest version

* Auto-format code using https://github.com/python/black and add checker to CI. Tell Flake8 to use Black's recommended line length of 88.

* Measure coverage only for the `slacker_cli` package, this prevents Coveralls including `/home/travis/virtualenv/...` and misreporting the coverage as ~29% instead of ~85%!

![image](https://user-images.githubusercontent.com/1324225/58172146-66092e00-7ca0-11e9-866e-c0f6fc67d3f2.png)

https://coveralls.io/builds/23518807
