### PR TITLE
CI: Fix PyPy3 build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov


### PR DESCRIPTION
Since creating PR https://github.com/juanpabloaj/slacker-cli/pull/40, `pypy3` is not working on GitHub Actions for macOS. We can be more specific and use `pypy-3.8`.