### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,20 +21,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/requirements-dev.txt') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["pypy3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         include:
           # Include new variables for Codecov
           - { codecov-flag: GHA_Ubuntu, os: ubuntu-latest }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
           - { codecov-flag: GHA_Windows, os: windows-latest }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -33,7 +33,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:
@@ -52,7 +52,7 @@ jobs:
           tox -e py
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           flags: ${{ matrix.codecov-flag }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,6 @@ jobs:
       matrix:
         python-version: ["pypy3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: [windows-latest, macos-latest, ubuntu-latest]
-        include:
-          # Include new variables for Codecov
-          - { codecov-flag: GHA_Ubuntu, os: ubuntu-latest }
-          - { codecov-flag: GHA_macOS, os: macos-latest }
-          - { codecov-flag: GHA_Windows, os: windows-latest }
 
     steps:
       - uses: actions/checkout@v3
@@ -54,5 +49,5 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          flags: ${{ matrix.codecov-flag }}
+          flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.12.0
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: ["--target-version", "py37"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.11.4
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -28,7 +28,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ setup(
     packages=["slacker_cli"],
     test_suite="tests",
     entry_points={"console_scripts": ["slacker=slacker_cli:main"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/slacker_cli/__init__.py
+++ b/slacker_cli/__init__.py
@@ -6,18 +6,13 @@
 import argparse
 import os
 import sys
+import warnings
+from urllib.parse import quote
 
 import requests
 
 from slacker import Slacker
 from slacker.utilities import get_item_id_by_name
-
-try:
-    from urllib import quote as urllib_quote
-except ImportError:
-    from urllib.parse import quote as urllib_quote
-
-import warnings
 
 warnings.filterwarnings("ignore", message=".*InsecurePlatformWarning.*")
 
@@ -50,7 +45,7 @@ class SlackerCliError(Exception):
 def post_message_as_slackbot(team, token, channel, message):
     url = "https://{team}.slack.com/services/hooks/slackbot"
     url += "?token={token}&channel={channel}"
-    url = url.format(team=team, token=token, channel=urllib_quote(channel))
+    url = url.format(team=team, token=token, channel=quote(channel))
     res = requests.post(url, message)
     if res.status_code != 200:
         raise SlackerCliError(f"{res.content}:'{url}'")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, py310, pypy3
+envlist = py{37, 38, 39, 310, 311, 312, py3}
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

And test on the 3.12-dev prerelease, and drop support for EOL Python 3.6, EOL since 2021-12-23.

Also bump GitHub Actions and pre-commit, simplify config, and remove some redundant Python 2 code.